### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/src/AsyncStateMachine/AsyncStateMachine.csproj
+++ b/src/AsyncStateMachine/AsyncStateMachine.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/AsyncStateMachine/AsyncStateMachine.csproj
+++ b/src/AsyncStateMachine/AsyncStateMachine.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.3" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/AsyncStateMachine/AsyncStateMachine.csproj
+++ b/src/AsyncStateMachine/AsyncStateMachine.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/AsyncStateMachine/StateMachine.cs
+++ b/src/AsyncStateMachine/StateMachine.cs
@@ -1,6 +1,6 @@
-﻿using AsyncStateMachine.Callbacks;
+﻿using AsyncKeyedLock;
+using AsyncStateMachine.Callbacks;
 using AsyncStateMachine.Contracts;
-using NeoSmart.AsyncLock;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Subjects;
@@ -23,7 +23,7 @@ namespace AsyncStateMachine
         private readonly ICallbackFilter _filter;
         private readonly ICallbackExecutor _executor;
         private readonly StateMachineConfiguration<TTrigger, TState> _configuration;
-        private readonly AsyncLock _asyncLock;
+        private readonly AsyncNonKeyedLocker _asyncLock;
 
         private TState? _currentState;
         private bool _disposed;
@@ -60,7 +60,7 @@ namespace AsyncStateMachine
             _subject = subject ?? throw new ArgumentNullException(nameof(subject));
             _filter = filter ?? throw new ArgumentNullException(nameof(filter));
             _executor = executor ?? throw new ArgumentNullException(nameof(executor));
-            _asyncLock = new AsyncLock();
+            _asyncLock = new AsyncNonKeyedLocker();
         }
 
         #endregion


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144